### PR TITLE
Fix warning on compilation

### DIFF
--- a/level3addr.h
+++ b/level3addr.h
@@ -217,9 +217,9 @@ ostream &operator<< (ostream &out, const Level3Addr &a) {
 	return out << str;
 	break;
       default:
-	return out << "invalidL3addr";
 	break;
     }
+    return out << "invalidL3addr";
 }
 
 Level3Addr l3mask (int nb) {


### PR DESCRIPTION
g++ warns :
level3addr.h: In function 'std::ostream& rzpnet::operator<<(std::ostream&, const rzpnet::Level3Addr&)':
level3addr.h:223: warning: control reaches end of non-void function

Move statement so function always returns something.